### PR TITLE
Pulling from pages

### DIFF
--- a/widget-loader-acf.php
+++ b/widget-loader-acf.php
@@ -1,7 +1,6 @@
 <?php
 
 $key = 'widget_mosaic-grid';
-$choices = self::$config['image_choices'];
 $widgetplacement = self::$config['tab_placement'];
 $post_types = self::$config['post_types'];
 
@@ -84,7 +83,7 @@ $widget_config = array (
           'key' => $key . '_advanced_details_tab',
           'label' => 'Advanced Details',
           'type' => 'tab',
-          'placement' => 'left',
+		  'placement' => $widgetplacement,
         ),
         array (
           'key' => $key . '_no_text',
@@ -93,20 +92,20 @@ $widget_config = array (
           'type' => 'true_false',
           'layout' => 'horizontal',
         ),
-        array (
-          'key' => $key . '_text_color',
-          'label' => 'Text Colour',
-          'name' => 'text_color',
-          'type' => 'color_picker',
-          'layout' => 'horizontal'
-        ),
-        array (
-          'key' => $key . '_button_color',
-          'label' => 'Button Colour',
-          'name' => 'button_color',
-          'type' => 'color_picker',
-          'layout' => 'vertical',
-        ),
+        // array (
+        //   'key' => $key . '_text_color',
+        //   'label' => 'Text Colour',
+        //   'name' => 'text_color',
+        //   'type' => 'color_picker',
+        //   'layout' => 'horizontal'
+        // ),
+        // array (
+        //   'key' => $key . '_button_color',
+        //   'label' => 'Button Colour',
+        //   'name' => 'button_color',
+        //   'type' => 'color_picker',
+        //   'layout' => 'vertical',
+        // ),
       ),
     ),
   ),


### PR DESCRIPTION
Pulling this widget out from pages. Same mark up so no need for a migration...

Do we want the colour fields?

JSON:

```"blocks": [
{
"image": {
"ID": 319736,
"id": 319736,
"title": "3ae6aebeff78ffe4d3cfdf4a906db0e3.jpg",
"filename": "3ae6aebeff78ffe4d3cfdf4a906db0e3.jpg",
"url": "http://shortlist.dev/app/uploads/2017/08/3ae6aebeff78ffe4d3cfdf4a906db0e3.jpg",
"alt": "",
"author": "0",
"description": "",
"caption": "",
"name": "3ae6aebeff78ffe4d3cfdf4a906db0e3-jpg-2",
"date": "2017-08-17 13:17:19",
"modified": "2017-08-18 11:03:13",
"mime_type": "image/jpeg",
"type": "image",
"icon": "http://shortlist.dev/wp/wp-includes/images/media/default.png",
"width": 980,
"height": 551,
"sizes": {...}
},
"link": "http://link.com",
"line_one": "Line uno",
"line_two": "Line duo",
"button_text": "Click Here",
"no_text": false,
}
],
```